### PR TITLE
PR: [Bug] Geteilte Schemas fixen und vereinheitlichen (#228)

### DIFF
--- a/packages/server/src/services/past-workouts.ts
+++ b/packages/server/src/services/past-workouts.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import {
   StatusCode,
   ErrorCode,
-  WorkoutSchema
+  PastWorkoutSchema
 } from "@momentum/shared";
 import { ok, nok } from "$api/response";
 import { PastWorkout } from "$models/past-workout";
@@ -17,7 +17,7 @@ import type { ErrorCodeValue } from "@momentum/shared";
   Erstellt ein neues erledigtes Workout. 
 */
 export const createPastWorkout = async (ctx: Context) => {
-  const { success, error, data } = WorkoutSchema.safeParse(ctx.request.body);
+  const { success, error, data } = PastWorkoutSchema.safeParse(ctx.request.body);
 
   if(!success) {
     return nok(
@@ -79,7 +79,7 @@ export const getPastWorkouts = async (ctx: Context) => {
 export const updatePastWorkout = async (ctx: Context) => {
   const { id } = ctx.params;
   
-  const { success, error, data } = WorkoutSchema
+  const { success, error, data } = PastWorkoutSchema
     .partial()
     .safeParse(ctx.request.body);
 

--- a/packages/server/src/services/workouts.ts
+++ b/packages/server/src/services/workouts.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import {
   StatusCode,
   ErrorCode,
-  SplitSchema
+  WorkoutSchema
 } from "@momentum/shared";
 import { ok, nok } from "$api/response";
 import { Workout } from "$models/workout";
@@ -17,7 +17,7 @@ import type { ErrorCodeValue } from "@momentum/shared";
   Erstellt einen neues Workout.
 */
 export const createWorkout = async (ctx: Context) => {
-  const { success, error, data } = SplitSchema.safeParse(ctx.request.body);
+  const { success, error, data } = WorkoutSchema.safeParse(ctx.request.body);
 
   if(!success) {
     return nok(
@@ -80,7 +80,7 @@ export const getWorkouts = async (ctx: Context) => {
 export const updateWorkout = async (ctx: Context) => {
   const { sid } = ctx.params;
 
-  const { success, error, data } = SplitSchema
+  const { success, error, data } = WorkoutSchema
     .partial()
     .safeParse(ctx.request.body);
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -134,115 +134,56 @@ export const LoginSchema = z.object({
 export type LoginSchemaType = z.infer<typeof LoginSchema>;
 
 /**
-  Schema für eine Übung.
-*/
-export const ExerciseSchema = z.object({
-  /**
-    ID.
-  */
-  id: z.string(),
-
-  /**
-    Name.
-  */
-  name: z.string(),
-
-  /**
-    Anzahl der Wiederholdungen.
-  */
-  repetitions: z.number().int().positive(),
-
-  /**
-    Anzahl der Sätze.
-  */
-  sets: z.number().int().positive(),
-
-  /**
-    Verwendendes Gewicht.
-  */
-  weight: z.number().nonnegative().optional(),
-
-  /**
-    Dauer.
-  */
-  duration: z.number().nonnegative().optional(),
-
-  /**
-    Liste von beanspruchten Muskelgruppen.
-  */
-  muscleGroups: z.array(z.string()),
-
-  /**
-    Gerätinstellungen.
-  */
-  deviceSetting: z.string().optional(),
-
-  /**
-    Notiz.
-  */
-  note: z.string().optional()
-});
-
-export type ExerciseSchemaType = z.infer<typeof ExerciseSchema>;
-
-/**
-  Schema für ein Workout.
+  Schema für einen Trainingsplan.
 */
 export const WorkoutSchema = z.object({
   /**
-    ID.
+    Name.
   */
-  id: z.string(),
+  name: z
+    .string()
+    .min(1)
+    .max(64),
 
   /**
-    Datum.
+    Beschreibung.
   */
-  date: z.string(),
+  description: z
+    .string()
+    .max(256)
+    .optional(),
 
   /**
-    Übungen.
+    Liste von Übungen.
   */
-  exercises: z.array(ExerciseSchema)
+  exercises: z.array(
+    z.object({
+      exerciseId: z.string(),
+      sets: z
+        .number()
+        .positive(),
+      reps: z
+        .number()
+        .positive()
+    })
+  )
 });
 
 export type WorkoutSchemaType = z.infer<typeof WorkoutSchema>;
 
 /**
-  Schema für einen Split.
+  Schema für erledigte Workouts.
 */
-export const SplitSchema = z.object({
+export const PastWorkoutSchema = WorkoutSchema.extend({
   /**
-    ID.
+    Zeitpunkt des Starts.
   */
-  id: z.string(),
+  startedAt: z.date(),
 
   /**
-    Name.
+    Zeitpunkt des Endes.
   */
-  name: z.string(),
-
-  /**
-    Workouts.
-  */
-  workouts: z.array(z.object({
-    type: z.enum([
-      "Push", 
-      "Pull", 
-      "Legs", 
-      "Upper Body", 
-      "Lower Body", 
-      "Full Body", 
-      "Cardio", 
-      "Rest",
-      "Arms",
-      "Chest and Back",
-      "Shoulders and Arms",
-      "Chest",
-      "Back",
-      "Shoulders"
-    ]),
-    workout: WorkoutSchema
-  }))
+  finishedAt: z.date()
 });
 
-export type SplitSchemaType = z.infer<typeof SplitSchema>;
+export type PastWorkoutSchemaType = z.infer<typeof PastWorkoutSchema>;


### PR DESCRIPTION
Diese PR versucht, Inkonsistenzen bei den Namen und Strukturen der Schemas im `@momentum/shared`-Package zu beheben.

- `SplitSchema` -> `WorkoutSchema`
- `WorkoutSchema` -> `PastWorkoutSchema`
- `ExerciseSchema` entfernt

Das ursprüngliche `SplitSchema` hat sich auf **tatsächliche Splits** bezogen, nicht auf **Trainingspläne**. Da Splits eventuell erst später ein Feature werden, wurde es entfernt.

Close: #228.